### PR TITLE
Indexing music collections includes non-music files

### DIFF
--- a/lib/play/library.rb
+++ b/lib/play/library.rb
@@ -32,6 +32,21 @@ module Play
       end
     end
 
+    # Removes an songs in the database that do not exist or are not readable
+    # by AudioInfo
+    #
+    # Returns nothing.
+    def self.prune_songs
+      Song.all.each do |song|
+        begin
+          fs_get_artist_and_title_and_album(song.path)
+        rescue AudioInfoError
+          print "'#{song.path}' is bad, removing from database.\n"
+          song.destroy
+        end
+      end
+    end
+
     # Imports a song into the database. This will identify a file's artist and
     # albums, run through the associations, and so on. It should be idempotent,
     # so you should be able to run it repeatedly on the same set of files and
@@ -53,6 +68,8 @@ module Play
                     :album => album,
                     :title => title)
       end
+    rescue AudioInfoError => error
+      print "'#{path}' failed to import due to #{error.inspect}\n"
     end
 
     # Splits a music file up into three constituent parts: artist, title,
@@ -68,7 +85,6 @@ module Play
                info.title.try(:strip),
                info.album.try(:strip)
       end
-    rescue AudioInfoError
     end
   end
 end


### PR DESCRIPTION
Because the rescue from an AudioInfo error on non-music files happens in the file gathering stage and not in the Song ActiveRecord creating stage, you can end up with lots of junk in your database. This branch fixes that and adds a function people can call from console if they need to clean up existing databases (we don't call it on every full-song import in case people use remove-able storage as all or part of their music library).
