### PR TITLE
Revert "Revert "Don't import things that AudioInfo can't parse and provi...

### DIFF
--- a/lib/play/library.rb
+++ b/lib/play/library.rb
@@ -32,6 +32,21 @@ module Play
       end
     end
 
+    # Removes an songs in the database that do not exist or are not readable
+    # by AudioInfo
+    #
+    # Returns nothing.
+    def self.prune_songs
+      Song.all.each do |song|
+        begin
+          fs_get_artist_and_title_and_album(song.path)
+        rescue AudioInfoError
+          print "'#{song.path}' is bad, removing from database.\n"
+          song.destroy
+        end
+      end
+    end
+
     # Imports a song into the database. This will identify a file's artist and
     # albums, run through the associations, and so on. It should be idempotent,
     # so you should be able to run it repeatedly on the same set of files and
@@ -53,6 +68,7 @@ module Play
                     :album => album,
                     :title => title)
       end
+    rescue AudioInfoError
     end
 
     # Splits a music file up into three constituent parts: artist, title,
@@ -68,7 +84,6 @@ module Play
                info.title.try(:strip),
                info.album.try(:strip)
       end
-    rescue AudioInfoError
     end
   end
 end


### PR DESCRIPTION
...de pruning function for databases that have gotten messed up (or music libraries which have deleted files)" and remove information output of what things weren't imported.
## This reverts commit abbed94c20edb236c1d9d539f7ee1815d972f4db but also removes information output of what things weren't imported (from the original commit that was reverted).

So, not mentioned in too much detail in the original branch -
fs_getmetadata will raise an AudioInfoError if the file isn't of a parseable type (note that this list isn't extensive, I'm fairly sure my Homeworld 2 ripped AIFs aren't included). If this is caught and ignored in the fs_getmetadata call then import_song will still create an entry for it because it can work with nil values. So we rescue in import_song and because fs_getmetadata is a necessary call before the ActiveRecords are created we can assume that invalid files won't be imported as 'songs.'

Additionally the logic has been tweaked to find/create Artists/Albums separately from song record creation and to update a song if it already exists in the database. This should cause less pain to people who are in the process of cleaning up their library metadata.

Finally prune_songs isn't called from anywhere, but I've used it periodically in irb and its handy if I screw up my library or we decide to pull music from the library.
