### PR TITLE
Select correct section of history for displaying recently played songs.

### DIFF
--- a/lib/play/app.rb
+++ b/lib/play/app.rb
@@ -49,7 +49,8 @@ module Play
     end
 
     get "/" do
-      @recent   = History.limit(3).order('created_at').collect(&:song)
+      @recent   = History.limit(3+1).order('created_at desc').collect(&:song)
+      @recent   = @recent.reverse[0..-2]
       @current  = current_song
       @songs    = [@current]
       @songs   << Song.queue.includes(:album, :artist, :votes).all


### PR DESCRIPTION
The recently played song list is selected from the history using the created_at column which defaults (at least on my setup) to ascending which means you get the oldest songs in the history.

Instead, select in descending order X+1 records (the +1 is for the song which is currently playing). Then reverse the order so they go in ascending order when displayed and remove the current song (the last element in the collection).
