### PR TITLE
If the album_art_url for a song is bad, print an album name.

### DIFF
--- a/lib/play/song.rb
+++ b/lib/play/song.rb
@@ -31,6 +31,10 @@ module Play
       album.art_url
     end
 
+    def valid_album_art_url?
+      not (album_art_url.nil? or album_art_url.empty?)
+    end
+
     # A nice, human-readable way of describing the playcount.
     #
     # Returns a String.

--- a/lib/play/templates/song.mustache
+++ b/lib/play/templates/song.mustache
@@ -1,7 +1,22 @@
 <div class="song {{#now_playing?}}now-playing{{/now_playing?}}">
-  <div class="album">
-    <a href="/album/{{album_id}}"><img src="{{album_art_url}}" width="75" height="75" title="{{album_name}}" /></a>
-  </div>
+  {{#valid_album_art_url?}}
+    <div class="album_art">
+      <a href="/album/{{album_id}}"><img src="{{album_art_url}}" width="75" height="75" title="{{album_name}}" /></a>
+    </div>
+  {{/valid_album_art_url?}}
+  {{^valid_album_art_url?}}
+    <div class="album_name">
+      <span class="fucking-slash">/</span>
+      <a href="/album/{{album_id}}">
+        {{^album_name.nil?}}
+          {{album_name}}
+        {{/album_name.nil?}}
+        {{#album_name.nil?}}
+          Untitled Album
+        {{/album_name.nil?}}
+      </a>
+    </div>
+  {{/valid_album_art_url?}}
 
   <div class="star">
     <a href="/star/{{id}}" title="star song">☆</a>

--- a/public/css/base.css
+++ b/public/css/base.css
@@ -116,14 +116,21 @@ a:hover{
 .song .star a{
   color: #ccc;
 }
-.song .artist{
+.song .artist, .song .album_name{
   padding-top: 3px;
   padding-left: 40px;
   font-size: 14px;
   font-weight: 500;
 }
-.song .artist a{
+.song .album_name{
+  margin-right: 25px;
+  float: right;
+}
+.song .artist a, .song .album_name a{
   color: #bcbcbc;
+}
+.song .album_name .fucking_slash a{
+  color: #e9e9e9;
 }
 .song .title{
   margin-bottom: 5px;
@@ -136,11 +143,11 @@ a:hover{
 .song .title a{
   color: #424242;
 }
-.song .album{
+.song .album_art{
   margin: 13px 25px;
   float: right;
 }
-.song .album img{
+.song .album_art img{
   border: 1px solid #bcbcbc;
   box-shadow: 0px 3px 4px #eee;
   border-radius: 3px;


### PR DESCRIPTION
Some annoying nesting in song.mustache for this one, but its nicer than seeing an unfilled box when there is no art_url for an album.

I would just do album_art_url.nil? but I somehow got nil art_url's producing strings in the output so I put valid_album_art_url? into Song. I don't like having it there but I don't see a better place... I would appreciate someone in the templating end weighing in.
