### PR TITLE
Use the users login if the office_string has not been set

### DIFF
--- a/lib/play/office.rb
+++ b/lib/play/office.rb
@@ -10,7 +10,9 @@ module Play
       return unless string_cache
       users = []
       string_cache.split(',').each do |string|
-        users << User.find_by_office_string(string.downcase)
+        user = User.find_by_office_string(string.downcase)
+        user ||= User.where(:office_string => nil, :login => string.downcase).first
+        users << user
       end
       users.compact
     end

--- a/test/office_test.rb
+++ b/test/office_test.rb
@@ -16,11 +16,13 @@ context "Office" do
     assert_equal "holman,kneath", Play::Office.user_string
   end
 
-  test "users are returned based on office string" do
+  test "users are returned based on office string or login" do
     holman = Play::User.create(:office_string => 'holman')
     kneath = Play::User.create(:office_string => 'kneath')
+    trobrock = Play::User.create(:login => 'trobrock')
+    neevor = Play::User.create(:login => 'neevor', :office_string => "neevor2")
     
-    Play::Office.stubs(:user_string).returns("holman,defunkt")
-    assert_equal [holman], Play::Office.users
+    Play::Office.stubs(:user_string).returns("holman,defunkt,trobrock,neevor")
+    assert_equal [holman,trobrock], Play::Office.users
   end
 end


### PR DESCRIPTION
This enables the use of the github username as the office_string without setting it. So our office app that returns the user string can just use the github usernames.
