### PR TITLE
Make the 'find' command in library.fs_songs follow symbolic links.

### DIFF
--- a/lib/play/library.rb
+++ b/lib/play/library.rb
@@ -17,7 +17,7 @@ module Play
     #
     # Returns an Array of String file paths.
     def self.fs_songs(path)
-      `find "#{path}" -type f ! -name '.*'`.split("\n")
+      `find "#{path}" -L -type f ! -name '.*'`.split("\n")
     end
 
     # Imports an array of songs into the database.


### PR DESCRIPTION
The reason for this patch is because I'm keeping a large music on a Drobo and I have a symbolic link in my ~/Music directory to said share so that Music applications will index it as normal.

Before this the 'find' command issued by Library.fs_songs ignored symbolic links instead of traversing them. 
