### PR TITLE
play index follows symbolic links

### DIFF
--- a/lib/play/library.rb
+++ b/lib/play/library.rb
@@ -17,7 +17,7 @@ module Play
     #
     # Returns an Array of String file paths.
     def self.fs_songs(path)
-      `find "#{path}" -L -type f ! -name '.*'`.split("\n")
+      `find -L "#{path}" -type f ! -name '.*'`.split("\n")
     end
 
     # Imports an array of songs into the database.


### PR DESCRIPTION
For people who are trying to use play with numerous remote libraries symbolic links to network shares make an easy solution. This patch allows the play index command to traverse symbolic links instead of ignoring them.
