### PR TITLE
Fix some crashing when first starting up or switching songs manually

### DIFF
--- a/app/models/queue.rb
+++ b/app/models/queue.rb
@@ -83,6 +83,9 @@ module Play
     #
     # Returns nothing.
     def self.pad
+      current_song = Song.find(Play::Player.now_playing.id)
+      add_song current_song if not queued?(current_song)
+
       if Play::Queue.songs.size < 3
         add_song Song.new(Play::Player.app.tracks.any.get.persistent_ID.get)
       end

--- a/app/realtime.rb
+++ b/app/realtime.rb
@@ -19,7 +19,7 @@ class Realtime < Rack::WebSocket::Application
 
     @timer = EM::PeriodicTimer.new(1) do
       if last != last=current
-        Play::Queue.clean
+        Play::Queue.clean if not Play::Player.now_playing.nil?
         send_data last
       end
       sleep 0.5


### PR DESCRIPTION
Added a condition to clean the queue only if there is a song playing.

Add the current song to the queue if it's not in it already. This is
caused when first starting the program or manually switching songs and
would cause the server to crash.
