### PR TITLE
Next set default content_type to json

### DIFF
--- a/app/api/control.rb
+++ b/app/api/control.rb
@@ -4,8 +4,6 @@ module Play
   class App < Sinatra::Base
 
     get "/now_playing" do
-      content_type :json
-      
       if Player.now_playing
         song = Player.now_playing
         song.starred = current_user.starred?(song)

--- a/app/app.rb
+++ b/app/app.rb
@@ -37,6 +37,8 @@ module Play
     before do
       return if ENV['RACK_ENV'] == 'test'
 
+      content_type :json
+
       session_not_required = request.path_info =~ /\/login/ ||
                              request.path_info =~ /\/auth/
 
@@ -67,10 +69,12 @@ module Play
     end
 
     get "/" do
+      content_type :html
       mustache :index
     end
 
     get "/logout" do
+      content_type :html
       logout!
       redirect 'https://github.com'
     end


### PR DESCRIPTION
Re: #90

Set html content-type for applicable pages.
Remove redundant json content-type declaration for '/now_playing'.
