### PR TITLE
Next bootstrap check for redis-server instead of redis-cli

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -18,7 +18,7 @@ echo ""
 #
 # Check for Redis
 #
-if test ! $(which redis-cli)
+if test ! $(which redis-server)
 then
   echo "  x You need to install Redis. If you use Homebrew, you can run:"
   echo "    brew install redis"


### PR DESCRIPTION
I'm lazy and don't have redis-cli setup correctly, maybe others don't either. Since play doesn't use it, shouldn't we check for redis-server?
