### PR TITLE
Small README updates for gotchas

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ During the bootstrap process you'll be asked to enter your [Pusher][pusher]
 credentials. This is optional, but it'll let you get realtime updates to your
 Play queue. It's like the future. Websockets and shit.
 
-At this point, you should be ready to play.
+Open up iTunes and start playing music from the iTunes DJ playlist.
+At this point, you should be ready to play:
 
     rake start
 


### PR DESCRIPTION
If you try to visit the play app and the iTunes DJ playlist is not already playing, the queue will just repeatedly error out.

Starting iTunes DJ and then navigating to the Queue again makes everything a-okay.

Added a small note to the README about that.
