### PR TITLE
Update uploader to support more extensions

### DIFF
--- a/app/api/system.rb
+++ b/app/api/system.rb
@@ -25,9 +25,9 @@ module Play
         tmpfile = file[:tempfile]
         name    = file[:filename]
 
-        # iTunes needs a filetype it likes, so fuck it, .mp3 it.
-        system "mv", tmpfile.path, tmpfile.path + '.mp3'
-        system "./script/add-to-itunes", tmpfile.path + '.mp3'
+        sane_path = File.join(File.dirname(tmpfile), name)
+        system "mv", tmpfile.path, sane_path
+        system "./script/add-to-itunes", sane_path
       end
 
       true


### PR DESCRIPTION
The approach is slightly dirtier than I'd like, but it works for now.

The uploader will now rename the tempfile to match the original filename that was specified by the params. This allows the iTunes importer to work correctly with all formats iTunes supports (with the previous implementation, uploading an m4a would fail, for example).
