### PR TITLE
Add initial iCloud/iTunes Match support

### DIFF
--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -22,7 +22,7 @@ module Play
     #
     # Returns an Array of Songs.
     def self.songs_by_name(name)
-      Player.library.file_tracks[Appscript.its.album.eq(name)].get.map do |record|
+      Player.library.shared_tracks[Appscript.its.album.eq(name)].get.map do |record|
         Song.new(record.persistent_ID.get)
       end
     end
@@ -31,7 +31,7 @@ module Play
     #
     # Returns an Array of Songs.
     def songs
-      Player.library.file_tracks[
+      Player.library.shared_tracks[
         Appscript.its.album.eq(name).and(Appscript.its.artist.eq(artist))
       ].get.map do |record|
         Song.new(record.persistent_ID.get)

--- a/app/models/queue.rb
+++ b/app/models/queue.rb
@@ -42,7 +42,7 @@ module Play
     #
     # Returns a Boolean of whether the song was added.
     def self.add_song(song)
-      Player.app.add(song.record.location.get, :to => playlist.get)
+      song.record.get.duplicate(:to => playlist.get)
     end
 
     # Public: Removes a song from the Queue.


### PR DESCRIPTION
- Tracks in the cloud can now be queued to the iTunes DJ Playlist
- Album song-searching now looks at tracks in the cloud
