### PR TITLE
The mpg123 client is now also able to return the current volume level

### DIFF
--- a/lib/play/clients/mpg123_client.rb
+++ b/lib/play/clients/mpg123_client.rb
@@ -62,5 +62,14 @@ module Play
     def self.volume=(volume)
       system "amixer set Master #{volume}% > /dev/null 2>&1"
     end
+    
+    # Get the current volume level
+    #
+    # Returns the current volume from 0 to 100
+    def self.volume
+      vol = `amixer get Master`.scan(/([0-9]+)%/).first.last
+      vol.to_i
+    end
+    
   end
 end


### PR DESCRIPTION
The mpg123 client is now also able to return the current volume level correctly. 

Tested on CentOS.

We needed this for building a volume control slider in Play. It fetches the current volume level on refresh, this worked fine when developing on a Mac, but when I pushed the code to our CentOS office machine it stopped working. Hence the fix, at least for CentOS. Further testing should be done by others on other machines.
