### PR TITLE
Updated Mocha to latest version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GEM
     json (1.6.5)
     metaclass (0.0.1)
     mime-types (1.17.2)
-    mocha (0.10.3)
+    mocha (0.11.1)
       metaclass (~> 0.0.1)
     multi_json (1.0.4)
     multipart-post (1.1.4)


### PR DESCRIPTION
Mocha 0.10.3 contained a bug so has been discontinued, which means it fails when installing the gems.

I haven't seen any issues since updating to 0.11.1, so should be ok for use.

Win.
