### PR TITLE
script/bootstrap doesn't set gh_org

### DIFF
--- a/config/play.example.yml
+++ b/config/play.example.yml
@@ -1,6 +1,6 @@
 gh_key: __OAUTH_KEY__
 gh_secret: __OAUTH_SECRET__
-gh_org:  __GITHUB_ORG__
+gh_org:
 pusher_app_id: __PUSHER_APP_ID__
 pusher_key: __PUSHER_KEY__
 pusher_secret: __PUSHER_SECRET__


### PR DESCRIPTION
bootstrap never sets this value, so the GitHub auth tries to authenticate against an organisation of "**GITHUB_ORG**"
