### PR TITLE
Automatically select iTunes DJ playlist on startup

### DIFF
--- a/app/app.rb
+++ b/app/app.rb
@@ -46,7 +46,9 @@ module Play
     Pusher.app_id =  Play.config.pusher_app_id
     Pusher.key = Play.config.pusher_key
     Pusher.secret = Play.config.pusher_secret
-
+    
+    Player.select_itunes_dj
+    
     Airfoil.enabled = Airfoil.installed?
     Airfoil.audio_source = "System Audio" if Airfoil.installed?
 

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -7,6 +7,17 @@ module Play
     def self.app
       Appscript.app('iTunes')
     end
+    
+    # Selects the iTunes DJ playlist, and causes it to be what's Now Playing by
+    # hitting play (and then pausing if we're currently paused)
+    def self.select_itunes_dj
+      currently_paused = now_playing.nil? || paused?
+
+      app.browser_windows.get.first.view.set(:to => app.playlists["iTunes DJ"])
+      play
+
+      pause if currently_paused
+    end
 
     # All songs in the library.
     def self.library


### PR DESCRIPTION
We can tell iTunes to queue up iTunes DJ automatically, instead of telling the user to do it like #165. iTunes needs a "play" command for iTunes DJ to become "Now Playing", so this patch additionally preserves the play/pause state by pausing afterwards as appropriate.
