### PR TITLE
Add Song#duration

### DIFF
--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -24,6 +24,9 @@ module Play
 
     # The last time a song was played
     attr_accessor :last_played
+    
+    # Duration in seconds, including fractions
+    attr_accessor :duration
 
     # Initializes a new Song.
     #
@@ -35,16 +38,18 @@ module Play
     def initialize(options)
       if options.kind_of?(String)
         song = Song.find(options)
-        @id     = song.id
-        @name   = song.name
-        @artist = song.artist
-        @album  = song.album
+        @id       = song.id
+        @name     = song.name
+        @artist   = song.artist
+        @album    = song.album
+        @duration = song.duration
       else
         @id     = options[:id]
         @name   = options[:name]
         @artist = options[:artist]
         @album  = options[:album]
         @last_played = options[:last_played]
+        @duration = options[:duration]
       end
     end
 
@@ -57,7 +62,8 @@ module Play
       new :id     => record.persistent_ID.get,
           :name   => record.name.get,
           :artist => record.artist.get,
-          :album  => record.album.get
+          :album  => record.album.get,
+          :duration => record.duration.get
     end
 
     # Finds a song in the database.
@@ -162,6 +168,7 @@ module Play
         :starred => starred || false,
         :queued  => queued?,
         :last_played => last_played_iso8601,
+        :duration => duration
       }
     end
 


### PR DESCRIPTION
Partially addresses #149. This commit brings duration into the Song model and exposes it in the resulting JSON, but doesn't do anything else.
