### PR TITLE
improve Firefox search field size

### DIFF
--- a/app/frontend/styles/base.css.scss
+++ b/app/frontend/styles/base.css.scss
@@ -189,7 +189,7 @@ form.search {
 
 .search input {
   width: 200px;
-  font-size: 25px;
+  font-size: 16px;
   color: $purple;
 }
 


### PR DESCRIPTION
In Firefox, the search field was so large that it jutted below the black bar it sits in.

This has no effect on the size in Safari and Chrome. In Firefox, the search field would look even better at 15px, but 15px bumps the field down too small in Safari and Chrome.
