### PR TITLE
V3 use bundle exec in bootstrap

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -107,7 +107,7 @@ else
 fi
 
 info 'data migrations'
-if rake db:migrate >> /tmp/play-bootstrap 2>&1
+if bundle exec rake db:migrate >> /tmp/play-bootstrap 2>&1
 then
   success 'data migrated'
 else


### PR DESCRIPTION
Use bundle exec so it doesn't throw this error when the gems aren't install outside the bundle.

`cannot load such file -- sinatra/activerecord/rake`
