### PR TITLE
V3 Make Play.music_path return full path.

### DIFF
--- a/app/play.rb
+++ b/app/play.rb
@@ -34,8 +34,8 @@ module Play
   # Returns a String.
   def self.music_path
     config = File.read('config/mpd.conf')
-    config.match(/music_directory\s+"(.+)"/)
-    $1
+    /^#?music_directory\s+"(?<music_path>(.+))"$/ =~ config
+    File.expand_path music_path
   end
 
   # The config file of Play. Contains things like keys, database config, and


### PR DESCRIPTION
I changed `Play.music_path` to return the full path to the base music directory. This also makes TagLib work with relative music paths since it needed the full path to the song. 

I could have just used an absolute path in mpd.conf but that would be too easy.

Regex also conforms to GitHub styleguide now... i think.
