### PR TITLE
Actually use the MYSQL_PASSWORD env in the bootstrap script.

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -92,7 +92,7 @@ fi
 info 'setting up mysql'
 
 [ $MYSQL_USER ] && user=$MYSQL_USER || user='root'
-[ $MYSQL_USER ] && password=$MYSQL_USER || password=''
+[ $MYSQL_PASSWORD ] && password=$MYSQL_PASSWORD || password=''
 
 if mysql -u $user --password="$password" -e 'USE play' >> /tmp/play-bootstrap 2>&1
 then


### PR DESCRIPTION
Yeah. It is requested to use MYSQL_PASSWORD env when the bootstrap script fails, but you don't actually every try to pull the var. This fixes that.
