### PR TITLE
This is a better method of ignoring all the art in public/art.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,5 @@ bin
 config/play.yml
 config/mpd.conf
 vendor
-public/art/*.png
-public/art/*.jpg
-public/art/*.jpeg
+public/art
+!public/art/.gitkeep


### PR DESCRIPTION
Just what it says. We'll ignore everything in the public/art directory except .gitkeep. Not sure if this might be eventual over kill, but who knows what people could eventually use for image extension beyond jpeg, jpg, and png.
