### PR TITLE
Allow play to work from a non-web root location. Example: http://<host>/play/

### DIFF
--- a/app/app.rb
+++ b/app/app.rb
@@ -23,9 +23,10 @@ module Play
       :views => "#{dir}/views"
     }
     set :github_options, {
-      :scopes    => "user",
-      :secret    => Play.config['github']['secret'],
-      :client_id => Play.config['github']['client_id'],
+      :scopes       => "user",
+      :secret       => Play.config['github']['secret'],
+      :client_id    => Play.config['github']['client_id'],
+      :callback_url => "#{Play.uri_prefix}/auth/github/callback",
     }
 
     db_name = (ENV['RACK_ENV'] == 'test' ? 'play_test' : 'play')

--- a/app/assets/css/application.css.scss.erb
+++ b/app/assets/css/application.css.scss.erb
@@ -34,7 +34,7 @@ a {
 		height: 48px;
 		width: 114px;
 		text-indent: -9999px;
-		background: url("/app/assets/images/play-logo.png") no-repeat center center;
+		background: url("<%= Play.uri_prefix %>/assets/play-logo.png") no-repeat center center;
 	}
 
 	#login {

--- a/app/assets/javascripts/behaviors/liking.coffee.erb
+++ b/app/assets/javascripts/behaviors/liking.coffee.erb
@@ -3,7 +3,7 @@ $ ->
     element = $(@)
     path = element.parents('.song').data('path')
 
-    $.post '/like',
+    $.post '<%= Play.uri_prefix %>/like',
       path: path
       (data) ->
         element.text('OK!')
@@ -12,7 +12,7 @@ $ ->
     element = $(@)
     path = element.parents('.song').data('path')
 
-    $.put '/like',
+    $.put '<%= Play.uri_prefix %>/like',
       path: path
       (data) ->
         element.text('OK!')
@@ -21,7 +21,7 @@ $ ->
     element = $(@)
     path = element.parents('.song').data('path')
 
-    $.delete '/like',
+    $.delete '<%= Play.uri_prefix %>/like',
       path: path
       (data) ->
         element.text('OK!')

--- a/app/assets/javascripts/behaviors/queuing.coffee.erb
+++ b/app/assets/javascripts/behaviors/queuing.coffee.erb
@@ -3,7 +3,7 @@ $ ->
     element = $(@)
     path = element.parents('.song').data('path')
 
-    $.post '/queue',
+    $.post '<%= Play.uri_prefix %>/queue',
       path: path
       (data) ->
         element.text(data)
@@ -14,7 +14,7 @@ $ ->
 
     $.ajax
       type: 'DELETE',
-      url:  '/queue',
+      url:  '<%= Play.uri_prefix %>/queue',
       data: {path: path},
       success: (data) ->
         element.text(data)

--- a/app/play.rb
+++ b/app/play.rb
@@ -50,6 +50,12 @@ module Play
   def self.config
     YAML::load(File.open('config/play.yml'))
   end
+
+  # The uri prefix we have set for play. This allows us to run play in a sub-directory
+  # on our webserver if we want.
+  def self.uri_prefix
+    self.config['uri_prefix']
+  end
 end
 
 require_relative 'app'

--- a/app/templates/layout.mustache
+++ b/app/templates/layout.mustache
@@ -4,25 +4,25 @@
   <meta name="apple-mobile-web-app-capable" content="yes">
   <title>Play</title>
 
-  <link rel="stylesheet" href="/assets/application.css">
+  <link rel="stylesheet" href="{{uri_prefix}}/assets/application.css">
 
-  <script type="text/javascript" src="/assets/application.js"></script>
+  <script type="text/javascript" src="{{uri_prefix}}/assets/application.js"></script>
 </head>
 
 <body>
   {{{not_running?}}}
 
-  <a href="/">Play</a>
+  <a href="{{uri_prefix}}/">Play</a>
   <div id="header">
-  <a href="/"><h1>Play</h1></a>
+  <a href="{{uri_prefix}}/"><h1>Play</h1></a>
 
   <section role="nav">
-    <form class="search" action="/search">
+    <form class="search" action="{{uri_prefix}}/search">
       <label for="q">Search</label>
       <input type="text" name="q" id="q" />
     </form>
     <span id="login">
-      <a href="/{{current_login}}">{{current_login}}</a>
+      <a href="{{uri_prefix}}/{{current_login}}">{{current_login}}</a>
     </span>
   </section>
 

--- a/app/templates/profile.mustache
+++ b/app/templates/profile.mustache
@@ -1,8 +1,8 @@
 <h1>{{login}}</h1>
 
 <ul>
-  <li><a href="/{{login}}">history</a></li>
-  <li><a href="/{{login}}/likes">likes</a></li>
+  <li><a href="{{uri_prefix}}/{{login}}">history</a></li>
+  <li><a href="{{uri_prefix}}/{{login}}/likes">likes</a></li>
 </ul>
 
 {{#songs}}

--- a/app/templates/song.mustache
+++ b/app/templates/song.mustache
@@ -1,17 +1,17 @@
 <div class="song" data-path="{{path}}">
-  <a href="/artist/{{artist_name}}/album/{{album_name}}">
-    <img src="/images/art/{{art_file}}" width="100" height="100" />
+  <a href="{{uri_prefix}}/artist/{{artist_name}}/album/{{album_name}}">
+    <img src="{{uri_prefix}}/images/art/{{art_file}}" width="100" height="100" />
   </a>
-  <div class="title"><a href="/artist/{{artist_name}}/song/{{title}}">{{title}}</a></div><div class="duration">({{duration}})</div>
+  <div class="title"><a href="{{uri_prefix}}/artist/{{artist_name}}/song/{{title}}">{{title}}</a></div><div class="duration">({{duration}})</div>
 
-  <div class="artist"><a href="/artist/{{artist_name}}">{{artist_name}}</a></div>
-  <div class="album"><a href="/artist/{{artist_name}}/album/{{album_name}}">{{album_name}}</a></div>
+  <div class="artist"><a href="{{uri_prefix}}/artist/{{artist_name}}">{{artist_name}}</a></div>
+  <div class="album"><a href="{{uri_prefix}}/artist/{{artist_name}}/album/{{album_name}}">{{album_name}}</a></div>
 
   <div class="controls">
     <a href="#" class="add">add</a>
     <a href="#" class="remove">remove</a>
-    <a href="/download/{{path}}">download song</a>
-    <a href="/download/album/{{path}}">download album</a>
+    <a href="{{uri_prefix}}/download/{{path}}">download song</a>
+    <a href="{{uri_prefix}}/download/album/{{path}}">download album</a>
     <a href="#" class="like">like</a>
     <a href="#" class="unlike">unlike</a>
     <a href="#" class="dislike">dislike</a>

--- a/app/views/layout.rb
+++ b/app/views/layout.rb
@@ -1,6 +1,10 @@
 module Play
   module Views
     class Layout < Mustache
+      def uri_prefix
+        Play.uri_prefix
+      end
+
       def current_login
         @current_user.login
       end

--- a/config.ru
+++ b/config.ru
@@ -4,7 +4,8 @@ require 'sprockets'
 assets = Sprockets::Environment.new
 assets.append_path 'app/assets/css'
 assets.append_path 'app/assets/javascripts'
+assets.append_path 'app/assets/images'
 
-map("/assets")   { run assets }
+map('/assets')   { run assets }
 
 map('/')         { run Play::App }

--- a/config/play.yml.example
+++ b/config/play.yml.example
@@ -10,3 +10,4 @@ github:
   org:
   client_id: 
   secret:
+uri_prefix:


### PR DESCRIPTION
So part of the idea of me running play through apache was to be able to run play as a sub directory on my server. This doesn't work as play is written currently. This fixes that problem, probably not the correct or most efficient way, but it is an approach to a solution.
- If you want to run play from the web host root, you don't need to do anything.
- If you want to run play from a web host non-root path, example `/play`, then you just stick /play in `config/play.yml` for `uri_prefix:` and you are off and running on the subdirectory.

I could not find any documentation (or much of any documentation for it) of how to wrap sprockets map with a uri prefix, but that would be an awesome feature. If you could do this, then you could just request assets with assets['file'] and not have to define the full static uri in the templates.

Not expecting this to be merged as it sits as this doesn't seem to be the most logical solution to the problem. It is just bringing an idea to the table and attaching some basic code.
