### PR TITLE
fix typos for starting play in production

### DIFF
--- a/script/play
+++ b/script/play
@@ -31,7 +31,7 @@ AVAILABLE COMMANDS:
   "
 }
 
-RACK_ENV=production
+export RACK_ENV=production
 
 # Handle play commands.
 case "$1" in

--- a/script/web
+++ b/script/web
@@ -14,7 +14,7 @@ fi
 # Production runs as daemonized and doesn't reload classes.
 if [ -n "$RACK_ENV" ]; then
   env="$RACK_ENV"
-  daemonize = '--daemonize'
+  daemonized='--daemonize'
 else
   env="development"
 fi


### PR DESCRIPTION
Hi,

at least on my machine (Linux Mint 13) `RACK_ENV` was never set in `script/web` unless i add `export` . 
The server never ran as daemon and therefore could not be stopped with `script/play stop`. 
In production the process list now shows `thin server` which is correct according to the `thin`-changelog:

`Set process name to 'thin server (0.0.0.0:3000)' when running as a daemon` .
