### PR TITLE
Start mpc if it's not running and a song has been added to the queue

### DIFF
--- a/app/models/queue.rb
+++ b/app/models/queue.rb
@@ -9,6 +9,7 @@ module Play
     def self.add(song,user)
       client.add(song.path)
       user.play!(song) if user
+      client.native :play if client.now_playing.nil?
       songs
     end
 


### PR DESCRIPTION
I noticed that if a queue is empty, mpc stops, so if we now add a track the the queue, Play kicks mpc back into life if it's not already started.
