### PR TITLE
Fix #233 [V3] Reading wrong "music_directory" key from mpd.config.

### DIFF
--- a/config/initializers/play.rb
+++ b/config/initializers/play.rb
@@ -12,8 +12,7 @@ module Play
   # Returns a String.
   def self.music_path
     config = File.read('config/mpd.conf')
-    config.match(/music_directory\s+"(.+)"/)
-    $1
+    config.scan(/^(?<!#)\s*music_directory\s+"([^"]*)"$/).last.first
   end
 
   # Directory where cached album art images will be stored.


### PR DESCRIPTION
Fix #233 [V3] Reading wrong "music_directory" key from mpd.config.

Testing an initalizer seems kinda weird almost like what is there is in the wrong place. I used these strings for testing locally.

```
#music_directory        "~/music1111"
#  music_directory        "~/music"
 music_directory "/some-dir-but-not-the-last-declaration"
music_directory "/the-dir-were-looking-for"
 some other crap
```
