### PR TITLE
Put homebrew in your PATH if found

### DIFF
--- a/script/play
+++ b/script/play
@@ -16,6 +16,11 @@
 # write something to help you out!)
 set -e
 
+# Put homebrew in your $PATH if brew executable is found
+if [ -d /usr/local/bin/brew ]; then
+  export PATH=/usr/local/bin:$PATH
+fi
+
 # Usage is grepped out of this file (i.e. The Tomayko Method).
 #/ usage: play [help|--help|-h] [command ...]
 play_usage() {


### PR DESCRIPTION
Invoking these scripts from straight-up ssh isn't loading customizations to your shell so this gets required executables in to your path.
