### PR TITLE
Use default rbenv when present

### DIFF
--- a/script/play
+++ b/script/play
@@ -17,8 +17,13 @@
 set -e
 
 # Put homebrew in your $PATH if brew executable is found
-if [ -d /usr/local/bin/brew ]; then
+if [ -f /usr/local/bin/brew ]; then
   export PATH=/usr/local/bin:$PATH
+fi
+
+# Put rbenv in your $PATH if the default path is found
+if [ -d ~/.rbenv/shims ]; then
+  export PATH=~/.rbenv/shims:$PATH
 fi
 
 # Usage is grepped out of this file (i.e. The Tomayko Method).


### PR DESCRIPTION
`script/play` rebundles outside of the rbenv otherwise.
