### PR TITLE
Use shoutcast

### DIFF
--- a/config/mpd.conf.example
+++ b/config/mpd.conf.example
@@ -4,7 +4,7 @@ decoder {
 }
 
 audio_output {
-  type             "httpd"
+  type             "shout"
   name             "Play Stream"
   encoder          "lame"
   port             "8000"
@@ -24,7 +24,7 @@ bind_to_address  "0.0.0.0"
 # Files and directories #######################################################
 #
 # This setting controls the top directory which MPD will search to discover the
-# available audio files and add them to the daemon's online database. This 
+# available audio files and add them to the daemon's online database. This
 # setting defaults to the XDG directory, otherwise the music directory will be
 # be disabled and audio files will only be accepted over ipc socket (using
 # file:// protocol) or streaming files over an accepted protocol.
@@ -32,20 +32,20 @@ bind_to_address  "0.0.0.0"
 # music_directory		"~/music"
 #
 # This setting sets the MPD internal playlist directory. The purpose of this
-# directory is storage for playlists created by MPD. The server will use 
+# directory is storage for playlists created by MPD. The server will use
 # playlist files not created by the server but only if they are in the MPD
 # format. This setting defaults to playlist saving being disabled.
 #
 #playlist_directory		"~/.mpd/playlists"
 #
 # This setting sets the location of the MPD database. This file is used to
-# load the database at server start up and store the database while the 
+# load the database at server start up and store the database while the
 # server is not up. This setting defaults to disabled which will allow
 # MPD to accept files over ipc socket (using file:// protocol) or streaming
 # files over an accepted protocol.
 #
 db_file			"~/.mpd/database"
-# 
+#
 # These settings are the locations for the daemon log files for the daemon.
 # These logs are great for troubleshooting, depending on your log_level
 # settings.
@@ -63,7 +63,7 @@ pid_file			"~/.mpd/pid"
 #
 # This setting sets the location of the file which contains information about
 # most variables to get MPD back into the same general shape it was in before
-# it was brought down. This setting is disabled by default and the server 
+# it was brought down. This setting is disabled by default and the server
 # state will be reset on server start up.
 #
 state_file			"~/.mpd/state"
@@ -107,14 +107,14 @@ sticker_file			"~/.mpd/sticker.sql"
 #
 #port				"6600"
 #
-# This setting controls the type of information which is logged. Available 
+# This setting controls the type of information which is logged. Available
 # setting arguments are "default", "secure" or "verbose". The "verbose" setting
 # argument is recommended for troubleshooting, though can quickly stretch
 # available resources on limited hardware storage.
 #
 #log_level			"default"
 #
-# If you have a problem with your MP3s ending abruptly it is recommended that 
+# If you have a problem with your MP3s ending abruptly it is recommended that
 # you set this argument to "no" to attempt to fix the problem. If this solves
 # the problem, it is highly recommended to fix the MP3 files with vbrfix
 # (available from <http://www.willwap.co.uk/Programs/vbrfix.php>), at which
@@ -132,13 +132,13 @@ sticker_file			"~/.mpd/sticker.sql"
 #
 #save_absolute_paths_in_playlists	"no"
 #
-# This setting defines a list of tag types that will be extracted during the 
+# This setting defines a list of tag types that will be extracted during the
 # audio file discovery process. Optionally, 'comment' can be added to this
 # list.
 #
 #metadata_to_use	"artist,album,title,track,name,genre,date,composer,performer,disc"
 #
-# This setting enables automatic update of MPD's database when files in 
+# This setting enables automatic update of MPD's database when files in
 # music_directory are changed.
 #
 auto_update	"yes"
@@ -153,7 +153,7 @@ auto_update	"yes"
 
 # Symbolic link behavior ######################################################
 #
-# If this setting is set to "yes", MPD will discover audio files by following 
+# If this setting is set to "yes", MPD will discover audio files by following
 # symbolic links outside of the configured music_directory.
 #
 #follow_outside_symlinks	"yes"
@@ -188,7 +188,7 @@ auto_update	"yes"
 #
 #password                        "password@read,add,control,admin"
 #
-# This setting specifies the permissions a user has who has not yet logged in. 
+# This setting specifies the permissions a user has who has not yet logged in.
 #
 #default_permissions             "read,add,control,admin"
 #
@@ -210,12 +210,12 @@ input {
 
 # Audio Output ################################################################
 #
-# MPD supports various audio output types, as well as playing through multiple 
-# audio outputs at the same time, through multiple audio_output settings 
+# MPD supports various audio output types, as well as playing through multiple
+# audio outputs at the same time, through multiple audio_output settings
 # blocks. Setting this block is optional, though the server will only attempt
 # autodetection for one sound card.
 #
-# See <http://mpd.wikia.com/wiki/Configuration#Audio_Outputs> for examples of 
+# See <http://mpd.wikia.com/wiki/Configuration#Audio_Outputs> for examples of
 # other audio outputs.
 #
 # An example of an ALSA output:
@@ -328,8 +328,8 @@ input {
 #
 #audio_output_format		"44100:16:2"
 #
-# If MPD has been compiled with libsamplerate support, this setting specifies 
-# the sample rate converter to use.  Possible values can be found in the 
+# If MPD has been compiled with libsamplerate support, this setting specifies
+# the sample rate converter to use.  Possible values can be found in the
 # mpd.conf man page or the libsamplerate documentation. By default, this is
 # setting is disabled.
 #
@@ -352,7 +352,7 @@ input {
 #replaygain_preamp		"0"
 #
 # This setting enables on-the-fly normalization volume adjustment. This will
-# result in the volume of all playing audio to be adjusted so the output has 
+# result in the volume of all playing audio to be adjusted so the output has
 # equal "loudness". This setting is disabled by default.
 #
 #volume_normalization		"no"
@@ -368,8 +368,8 @@ input {
 #
 #audio_buffer_size		"2048"
 #
-# This setting controls the percentage of the buffer which is filled before 
-# beginning to play. Increasing this reduces the chance of audio file skipping, 
+# This setting controls the percentage of the buffer which is filled before
+# beginning to play. Increasing this reduces the chance of audio file skipping,
 # at the cost of increased time prior to audio playback.
 #
 #buffer_before_play		"10%"
@@ -423,7 +423,7 @@ input {
 
 # Character Encoding ##########################################################
 #
-# If file or directory names do not display correctly for your locale then you 
+# If file or directory names do not display correctly for your locale then you
 # may need to modify this setting.
 #
 #filesystem_charset		"UTF-8"
@@ -458,4 +458,3 @@ input {
 #}
 #
 ###############################################################################
-


### PR DESCRIPTION
This changes the stream type to shoutcast. 
1. We need this so that the appropriate metadata is returned during the stream so callbacks can be used to detect when the song has changed.
2. We should just be using shoutcast, nuff said.
