### PR TITLE
always make paths an Array

### DIFF
--- a/script/cache-art
+++ b/script/cache-art
@@ -16,7 +16,7 @@ puts "Caching art for #{albums.count} albums..."
 FileUtils.mkdir_p 'public/images/art'
 
 count = 0
-paths.each do |path|
+Array(paths).each do |path|
   result = Song.new(:path => path).cache_album_art
   count += 1 if result
 end


### PR DESCRIPTION
Hi,

i noticed @javierburongarcia 's [comment in an issue](https://github.com/play/play/issues/314#issuecomment-22562245) where his only album in a folder caused problems. So i found out that there is not always an array returned and this PR fixes that case.
