### PR TITLE
Track-title truncated for long track titles in album view

### DIFF
--- a/app/assets/stylesheets/play.css.scss
+++ b/app/assets/stylesheets/play.css.scss
@@ -557,7 +557,12 @@ section[role="nav"] {
         a.track-title {
           color: #595959;
           padding-left: 10px;
-
+          // truncated text for long track-titles
+          text-overflow: ellipsis;
+          display: inline-block;
+          width: 72%;
+          white-space: nowrap;
+          overflow: hidden;
           &:hover {
             color: $pink;
           }


### PR DESCRIPTION
Just fixed a small problem in css when song titles are too long which broke the list view 
