### PR TITLE
Token Route

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -6,4 +6,12 @@ class AccountController < ApplicationController
     render :template => 'users/show'
   end
 
+  def token
+    if params[:back_to]
+      redirect_to params[:back_to] + "?token=" + current_user.token
+    else
+      redirect_to account_url
+    end
+  end
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Play::Application.routes.draw do
 
   get "account" => 'account#show'
+  get "account/token" => 'account#token'
   get "search" => 'songs#search'
   get "artists/:artist_name/songs/:title" => 'songs#show', :as => 'song'
   get "artists/:artist_name/albums/:name" => 'albums#show', :as => 'album'


### PR DESCRIPTION
This provides a way to send a user to their token

GET `/account/token` => opens a browser and redirects them to their account view and shows them their token.
GET `/accounts/token?back_to=play://fetch_token` redirects them to `play://fetch_token?token=2dsfd` so their app can handle it.
