### PR TITLE
mpd.queue.first -> mpd.current_song

### DIFF
--- a/app/models/play_queue.rb
+++ b/app/models/play_queue.rb
@@ -37,7 +37,7 @@ class PlayQueue
   #
   # Returns the current Song.
   def self.now_playing
-    if record = Play.mpd.queue.first
+    if record = Play.mpd.current_song
       Song.new(:path => record.file)
     end
   end


### PR DESCRIPTION
Beats grabbing the entire queue. Besides, if consume is not enabled, mpd.queue.first doesn't point to the currently playing song, but the first in the queue/playlist.
