### PR TITLE
v3-channels: use MPD supplied song data instead of reading it manually

### DIFF
--- a/app/controllers/channels_controller.rb
+++ b/app/controllers/channels_controller.rb
@@ -8,7 +8,7 @@ class ChannelsController < ApplicationController
   def add
     case params[:type]
     when /song/
-      song = Song.new(:path => params[:song_id])
+      song = Song.from_path(params[:song_id])
       @channel.add(song,current_user)
     when /album/
       artist = Artist.new(:name => params[:artist])
@@ -20,7 +20,7 @@ class ChannelsController < ApplicationController
   end
 
   def remove
-    song = Song.new(:path => params[:song_id])
+    song = Song.from_path(params[:song_id])
     @channel.remove(song,current_user)
     render :text => 'deleted!'
   end

--- a/app/controllers/queue_controller.rb
+++ b/app/controllers/queue_controller.rb
@@ -6,7 +6,7 @@ class QueueController < ApplicationController
   def create
     case params[:type]
     when /song/
-      song = Song.new(:path => params[:id])
+      song = Song.from_path(params[:id])
       Play.default_channel.add(song,current_user)
     when /album/
       artist = Artist.new(:name => params[:artist])
@@ -18,7 +18,7 @@ class QueueController < ApplicationController
   end
 
   def destroy
-    song = Song.new(:path => params[:id])
+    song = Song.from_path(params[:id])
     Play.default_channel.remove(song,current_user)
     render :text => 'deleted!'
   end

--- a/app/controllers/songs_controller.rb
+++ b/app/controllers/songs_controller.rb
@@ -12,7 +12,7 @@ class SongsController < ApplicationController
     # taglib needs a file extension (lol)
     new_tmp = File.join(File.dirname(tmpfile), File.basename(name))
     File.rename(tmpfile.path, new_tmp)
-    song    = Song.new(:path => new_tmp)
+    song    = Song.from_path(new_tmp)
 
     # Import into our collection
     path = File.join(Play.music_path, song.artist_name, song.album_name)
@@ -35,7 +35,7 @@ class SongsController < ApplicationController
   end
 
   def download
-    song = Song.new(:path => params[:path])
+    song = Song.from_path(params[:path])
     send_file(File.join(Play.music_path,song.path), :disposition => 'attachment')
   end
 end

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -30,7 +30,7 @@ class Album
       end
 
       results.map do |result|
-        Song.new(:path => result[:file])
+        Song.new(MPD::Song.new(result)) # fairly ugly
       end
     end
   end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -35,7 +35,7 @@ class Artist
     end
 
     records.map do |record|
-      Song.new(:path => record.file)
+      Song.new(record)
     end.reject{ |song| song.title.blank? }
   end
 

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -113,7 +113,7 @@ class Channel < ActiveRecord::Base
   # Returns the current Song.
   def now_playing
     if record = mpd.queue.first
-      Song.new(:path => record.file)
+      Song.new(record)
     end
   end
 
@@ -133,7 +133,7 @@ class Channel < ActiveRecord::Base
     end
 
     results.map do |result|
-      Song.new(:path => result.file)
+      Song.new(result)
     end
   end
 

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -4,6 +4,6 @@ class Like < ActiveRecord::Base
   attr_accessible :song_path, :user
 
   def song
-    Song.new(:path => song_path)
+    Song.from_path(song_path)
   end
 end

--- a/app/models/song_play.rb
+++ b/app/models/song_play.rb
@@ -11,6 +11,6 @@ class SongPlay < ActiveRecord::Base
   #
   # Returns a Song.
   def song
-    Song.new(:path => song_path)
+    Song.from_path(song_path)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,7 +23,7 @@ class User < ActiveRecord::Base
   # Returns an Array of Songs.
   def plays
     song_plays.map do |play|
-      Song.new(:path => play.song_path)
+      Song.from_path(play.song_path)
     end
   end
 
@@ -43,7 +43,7 @@ class User < ActiveRecord::Base
   # Returns an Array of Songs.
   def liked_songs(page=1, per_page=20)
     likes.paginate(:page => page, :per_page => per_page).order('created_at desc').map do |like|
-      Song.new(:path => like.song_path)
+      Song.from_path(like.song_path)
     end
   end
 

--- a/script/cache-art
+++ b/script/cache-art
@@ -17,7 +17,7 @@ FileUtils.mkdir_p 'public/images/art'
 
 count = 0
 Array(paths).each do |path|
-  result = Song.new(:path => path).cache_album_art
+  result = Song.from_path(path).cache_album_art
   count += 1 if result
 end
 

--- a/script/queue
+++ b/script/queue
@@ -35,7 +35,7 @@ loop do
       else
         # this is new, queue from the library
         puts "Auto-queuing a song from the library to the channel: #{channel.name}"
-        song = Song.new(:path => Play.library.files[:file].sample)
+        song = Song.from_path(Play.library.files[:file].sample)
       end
 
       channel.add(song, nil)

--- a/test/api/channels_test.rb
+++ b/test/api/channels_test.rb
@@ -166,7 +166,7 @@ class ChannelsTest < ActiveSupport::TestCase
     end
 
     test "POST /remove" do
-      @channel.add(Song.new(:path => %{Jeff Buckley/Grace/Lover, You Should've Come Over.mp3}),@user)
+      @channel.add(Song.from_path(%{Jeff Buckley/Grace/Lover, You Should've Come Over.mp3}),@user)
 
       authorized_post "/api/channels/#{@channel.id}/remove", @authorized_user, {:artist_name => @song.artist.to_param, :song_name => @song.to_param}
       parsed_response = parse_response(last_response)

--- a/test/models/song_test.rb
+++ b/test/models/song_test.rb
@@ -27,7 +27,7 @@ class SongTest < ActiveSupport::TestCase
   end
 
   test "knows equivalence" do
-    assert_equal Song.new(:path => 'Justice/Cross/Stress.mp3'), @song
+    assert_equal Song.from_path('Justice/Cross/Stress.mp3'), @song
   end
 
   test "finds a song by any" do


### PR DESCRIPTION
There's no reason really not to reuse the MPD::Song objects which already contain the data, which was pre-read and stored by MPD.

For filepaths, a new method is introduced which fetches a MPD::Song object for the specified path, and constructs a Song instance.
